### PR TITLE
added missing pytest-cov dev dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         "dev": [
             "flake8",
             "pytest",
+            "pytest-cov",
             "twine"
         ]
     },


### PR DESCRIPTION
Running pytest with the old setup would result in the following error:

```shell
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --cov=./
  inifile: /Users/ereinecke/Projects/github/my-otio-plugin/setup.cfg
  rootdir: /Users/ereinecke/Projects/github/my-otio-plugin
```

This resolves that issue by adding `pytest-cov` to expose the `--cov` argument in pytest.