### PR TITLE
Add/Move doc strings to top of example files 

### DIFF
--- a/otio_plugin_template/adapters/my_adapter.py
+++ b/otio_plugin_template/adapters/my_adapter.py
@@ -1,7 +1,3 @@
-import json
-import opentimelineio as otio
-
-
 """
 Super simple adapter example that takes a json formatted string and creates
 a Timeline.
@@ -22,6 +18,9 @@ raw_data = '''{
     }
 }'''
 """
+
+import json
+import opentimelineio as otio
 
 
 def read_from_string(input_str):

--- a/otio_plugin_template/schemadefs/my_schemadef.py
+++ b/otio_plugin_template/schemadefs/my_schemadef.py
@@ -1,3 +1,7 @@
+"""
+Simple schema for my thing
+"""
+
 import opentimelineio as otio
 
 


### PR DESCRIPTION
`otiopluginfo` fails if no doc strings are found at the top of the files. The adapter and schemadef examples failed as they were. This PR should fix this.